### PR TITLE
Add docker image for database

### DIFF
--- a/Database
+++ b/Database
@@ -1,0 +1,15 @@
+FROM mariadb:10.5 AS dumper
+
+ARG DB_PASSWORD
+
+COPY INTERNAL-SOURCE-LOAD/Models/DataModel.sql /docker-entrypoint-initdb.d/
+
+ENV MARIADB_ROOT_PASSWORD=${DB_PASSWORD}
+
+RUN sed -i 's/exec "$@"/echo "skipping..."/' /usr/local/bin/docker-entrypoint.sh
+
+RUN ["/usr/local/bin/docker-entrypoint.sh", "mysqld"]
+
+FROM mariadb:10.5
+
+COPY --from=dumper /var/lib/mysql /var/lib/mysql

--- a/INTERNAL-SOURCE-LOAD/Models/DataModel.sql
+++ b/INTERNAL-SOURCE-LOAD/Models/DataModel.sql
@@ -1,65 +1,109 @@
--- --------------------------------------------------------
--- Hôte:                         127.0.0.1
--- Version du serveur:           11.6.2-MariaDB - mariadb.org binary distribution
--- SE du serveur:                Win64
--- HeidiSQL Version:             12.8.0.6908
--- --------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS `TrainSchedule`;
+USE `TrainSchedule`;
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET NAMES utf8 */;
-/*!50503 SET NAMES utf8mb4 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+-- Listage de la structure de table TrainSchedule. trains
+CREATE TABLE IF NOT EXISTS `Trains`
+(
+    `Id`
+    int
+(
+    11
+) NOT NULL AUTO_INCREMENT,
+    `G` varchar
+(
+    50
+) NOT NULL,
+    `L` varchar
+(
+    50
+) DEFAULT NULL,
+    PRIMARY KEY
+(
+    `Id`
+)
+    ) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4;
+
+-- Les donnï¿½es exportï¿½es n'ï¿½taient pas sï¿½lectionnï¿½es.
+
+-- Listage de la structure de table TrainSchedule. trainstations
+CREATE TABLE IF NOT EXISTS `TrainStations`
+(
+    `Id`
+    int
+(
+    11
+) NOT NULL AUTO_INCREMENT,
+    `Name` varchar
+(
+    255
+) NOT NULL,
+    PRIMARY KEY
+(
+    `Id`
+)
+    ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4;
 
 
--- Listage de la structure de la base pour trainschedule
-CREATE DATABASE IF NOT EXISTS `trainschedule` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci */;
-USE `trainschedule`;
+-- Listage de la structure de table TrainSchedule. departures
+CREATE TABLE IF NOT EXISTS `Departures`
+(
+    `Id`
+    int
+(
+    11
+) NOT NULL AUTO_INCREMENT,
+    `DepartureStationName` varchar
+(
+    255
+) NOT NULL,
+    `DestinationStationName` varchar
+(
+    255
+) NOT NULL,
+    `ViaStationNames` text DEFAULT NULL,
+    `DepartureTime` datetime NOT NULL,
+    `Platform` varchar
+(
+    50
+) NOT NULL,
+    `Sector` varchar
+(
+    50
+) DEFAULT NULL,
+    `TrainStationId` int
+(
+    11
+) DEFAULT NULL,
+    `TrainId` int
+(
+    11
+) DEFAULT NULL,
+    PRIMARY KEY
+(
+    `Id`
+),
+    KEY `TrainStationId`
+(
+    `TrainStationId`
+),
+    KEY `TrainId`
+(
+    `TrainId`
+),
+    CONSTRAINT `departures_ibfk_1` FOREIGN KEY
+(
+    `TrainStationId`
+) REFERENCES `TrainStations`
+(
+    `Id`
+),
+    CONSTRAINT `departures_ibfk_2` FOREIGN KEY
+(
+    `TrainId`
+) REFERENCES `Trains`
+(
+    `Id`
+)
+    ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4;
 
--- Listage de la structure de table trainschedule. departures
-CREATE TABLE IF NOT EXISTS `departures` (
-  `Id` int(11) NOT NULL AUTO_INCREMENT,
-  `DepartureStationName` varchar(255) NOT NULL,
-  `DestinationStationName` varchar(255) NOT NULL,
-  `ViaStationNames` text DEFAULT NULL,
-  `DepartureTime` datetime NOT NULL,
-  `Platform` varchar(50) NOT NULL,
-  `Sector` varchar(50) DEFAULT NULL,
-  `TrainStationId` int(11) DEFAULT NULL,
-  `TrainId` int(11) DEFAULT NULL,
-  PRIMARY KEY (`Id`),
-  KEY `TrainStationId` (`TrainStationId`),
-  KEY `TrainId` (`TrainId`),
-  CONSTRAINT `departures_ibfk_1` FOREIGN KEY (`TrainStationId`) REFERENCES `trainstations` (`Id`),
-  CONSTRAINT `departures_ibfk_2` FOREIGN KEY (`TrainId`) REFERENCES `trains` (`Id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
-
--- Les données exportées n'étaient pas sélectionnées.
-
--- Listage de la structure de table trainschedule. trains
-CREATE TABLE IF NOT EXISTS `trains` (
-  `Id` int(11) NOT NULL AUTO_INCREMENT,
-  `G` varchar(50) NOT NULL,
-  `L` varchar(50) DEFAULT NULL,
-  PRIMARY KEY (`Id`)
-) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
-
--- Les données exportées n'étaient pas sélectionnées.
-
--- Listage de la structure de table trainschedule. trainstations
-CREATE TABLE IF NOT EXISTS `trainstations` (
-  `Id` int(11) NOT NULL AUTO_INCREMENT,
-  `Name` varchar(255) NOT NULL,
-  PRIMARY KEY (`Id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
-
--- Les données exportées n'étaient pas sélectionnées.
-
-/*!40103 SET TIME_ZONE=IFNULL(@OLD_TIME_ZONE, 'system') */;
-/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
-/*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40111 SET SQL_NOTES=IFNULL(@OLD_SQL_NOTES, 1) */;
+-- Les donnï¿½es exportï¿½es n'ï¿½taient pas sï¿½lectionnï¿½es.


### PR DESCRIPTION
This pull request includes significant changes to the database setup and schema for the `TrainSchedule` application. The changes involve updating the Docker setup for MariaDB and modifying the SQL schema to ensure consistency and proper table creation.

### Database Setup Improvements:
* Added a multi-stage Dockerfile for MariaDB to initialize the database with the `DataModel.sql` script and set the root password using an argument. (`Database`)

### SQL Schema Updates:
* Created the `TrainSchedule` database and updated the table creation statements to ensure they use consistent naming conventions and proper character sets. (`INTERNAL-SOURCE-LOAD/Models/DataModel.sql`)
* Added `CREATE TABLE IF NOT EXISTS` statements for `Trains`, `TrainStations`, and `Departures` tables, ensuring they follow the InnoDB engine and UTF8MB4 character set. (`INTERNAL-SOURCE-LOAD/Models/DataModel.sql`)
* Updated the `Departures` table to include foreign key constraints referencing `TrainStations` and `Trains` tables, ensuring referential integrity. (`INTERNAL-SOURCE-LOAD/Models/DataModel.sql`)